### PR TITLE
op3/t: nfc: advertise support for extended length NFC

### DIFF
--- a/configs/nfc/libnfc-nxp.conf
+++ b/configs/nfc/libnfc-nxp.conf
@@ -372,6 +372,12 @@ NFA_PROPRIETARY_CFG={05, FF, FF, 06, 81, 80, 70, FF, FF}
 #  If set to 1, NFCC is using bail out mode for either Type A or Type B poll.
 NFA_POLL_BAIL_OUT_MODE=0x01
 
+#################################################################################
+# Set max transceive length for IsoDep frames
+# Standard      0x105 (261)
+# Extended      0xFEFF (65279)
+ISO_DEP_MAX_TRANSCEIVE=0xFEFF
+
 ###############################################################################
 #White list of Hosts
 #This values will be the Hosts(NFCEEs) in the HCI Network.


### PR DESCRIPTION
device support for extended length NFC successfully tested with German
ID card and "AusweisApp2" (horribly unreliable, but working) on
cheeseburger (OnePlus 5).

This is also needed for Yubikey.